### PR TITLE
feat: implement booking list view with ascending StartDate sorting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@ Das Projekt ist eine Buchungsplattform für einen Garten, die es Familienmitglie
 - Nach jedem Schritt erfolgt ein Commit und Push.
 - **WICHTIG - Schrittweise Umsetzung**: Implementiere immer nur das, was explizit besprochen und geplant wurde. Vermeide es, zusätzliche Features oder Placeholder für zukünftige Funktionen zu erstellen, da dies die Issues zu groß macht und das Testen erschwert. Jedes Feature sollte vollständig und isoliert implementiert werden.
 - **KRITISCH - Strikte Issue-Fokussierung**: Implementiere AUSSCHLIESSLICH die in der Issue-Beschreibung geforderten Funktionen. NIEMALS zusätzliche Features wie Paging, Filterung, erweiterte Parameter oder "vorsorgliche" Funktionalitäten hinzufügen, die nicht explizit gefordert wurden. Dies verursacht unnötige Analyse-Zeit beim Review und macht PRs komplexer als nötig. Regel: Wenn es nicht im Issue steht, wird es nicht implementiert.
+- **OBLIGATORISCH - Frontend & Backend Synchronisation**: Bei JEDER Aufgabe IMMER sowohl Frontend als auch Backend betrachten und synchron halten. Änderungen an APIs, Datenstrukturen oder Funktionen müssen konsistent zwischen Frontend (.NET Core API) und Backend (Next.js) implementiert werden. Vergessene Frontend-Anpassungen führen zu Runtime-Fehlern und zusätzlicher Review-Zeit.
 
 ### 4.1 Obligatorische Reihenfolge bei Issue-Bearbeitung:
 1. **Branch-Setup** (Abschnitt 11.3 + 12.1) - IMMER zuerst!

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ Das Projekt ist eine Buchungsplattform für einen Garten, die es Familienmitglie
 - Die Umsetzung erfolgt Schritt für Schritt entlang dieses Plans.
 - Nach jedem Schritt erfolgt ein Commit und Push.
 - **WICHTIG - Schrittweise Umsetzung**: Implementiere immer nur das, was explizit besprochen und geplant wurde. Vermeide es, zusätzliche Features oder Placeholder für zukünftige Funktionen zu erstellen, da dies die Issues zu groß macht und das Testen erschwert. Jedes Feature sollte vollständig und isoliert implementiert werden.
+- **KRITISCH - Strikte Issue-Fokussierung**: Implementiere AUSSCHLIESSLICH die in der Issue-Beschreibung geforderten Funktionen. NIEMALS zusätzliche Features wie Paging, Filterung, erweiterte Parameter oder "vorsorgliche" Funktionalitäten hinzufügen, die nicht explizit gefordert wurden. Dies verursacht unnötige Analyse-Zeit beim Review und macht PRs komplexer als nötig. Regel: Wenn es nicht im Issue steht, wird es nicht implementiert.
 
 ### 4.1 Obligatorische Reihenfolge bei Issue-Bearbeitung:
 1. **Branch-Setup** (Abschnitt 11.3 + 12.1) - IMMER zuerst!

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,19 @@ Das Projekt ist eine Buchungsplattform für einen Garten, die es Familienmitglie
 - Hohe Sicherheitsstandards (Gerät hinter Fritzbox)
 - Entity Framework Core für Datenbankzugriff
 
+### Performance-Grundsätze
+**WICHTIG - Backend-First Prinzip**: Datenverarbeitung wie Sortierung, Filterung, Paginierung und Aggregation muss IMMER backend-seitig implementiert werden. Dies reduziert:
+- Netzwerk-Traffic (kleinere Datenmengen)
+- Client-seitige Verarbeitungszeit
+- Speicherverbrauch im Browser
+- Besonders kritisch auf schwacher Hardware (Raspberry Pi)
+
+**Beispiele:**
+- ❌ Client: `data.sort((a, b) => new Date(b.date) - new Date(a.date))`
+- ✅ Backend: API-Endpoint mit `ORDER BY startDate DESC`
+- ❌ Client: `data.filter(item => item.status === 'active')`
+- ✅ Backend: API-Parameter `?status=active`
+
 ## 1. Anforderungen aus requirements.md nutzen
 - Verwende die Datei `requirements.md` als zentrale Quelle für fachliche und technische Anforderungen.
 - Neue Issues, Features oder Tasks werden auf Basis der Anforderungen in `requirements.md` erstellt.

--- a/src/backend/Booking.Api.Tests/Unit/Features/Bookings/Queries/GetBookingsQueryHandlerTests.cs
+++ b/src/backend/Booking.Api.Tests/Unit/Features/Bookings/Queries/GetBookingsQueryHandlerTests.cs
@@ -1,0 +1,328 @@
+using AutoFixture;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Booking.Api.Data;
+using Booking.Api.Domain.ReadModels;
+using Booking.Api.Features.Bookings.Queries;
+using Booking.Api.Features.Bookings.DTOs;
+using Booking.Api.Domain.Enums;
+
+namespace Booking.Api.Tests.Unit.Features.Bookings.Queries;
+
+public sealed class GetBookingsQueryHandlerTests : IDisposable
+{
+    private readonly BookingDbContext context;
+    private readonly ILogger<GetBookingsQueryHandler> logger;
+    private readonly GetBookingsQueryHandler handler;
+    private readonly Fixture fixture;
+
+    public GetBookingsQueryHandlerTests()
+    {
+        var options = new DbContextOptionsBuilder<BookingDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        context = new BookingDbContext(options);
+        logger = Substitute.For<ILogger<GetBookingsQueryHandler>>();
+        handler = new GetBookingsQueryHandler(context, logger);
+        fixture = new Fixture();
+    }
+
+    public void Dispose()
+    {
+        context.Dispose();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnBookingsSortedByStartDateDescending()
+    {
+        // Arrange
+        var userId = fixture.Create<int>();
+        var olderBooking = CreateBookingReadModel(userId, startDate: new DateTime(2024, 1, 15));
+        var newerBooking = CreateBookingReadModel(userId, startDate: new DateTime(2024, 3, 20));
+        var newestBooking = CreateBookingReadModel(userId, startDate: new DateTime(2024, 4, 10));
+
+        context.BookingReadModels.AddRange(olderBooking, newerBooking, newestBooking);
+        await context.SaveChangesAsync();
+
+        var query = new GetBookingsQuery(
+            UserId: userId,
+            StartDate: null,
+            EndDate: null,
+            PageNumber: 1,
+            PageSize: 10
+        );
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(3);
+        result[0].StartDate.Should().Be(newestBooking.StartDate);
+        result[1].StartDate.Should().Be(newerBooking.StartDate);
+        result[2].StartDate.Should().Be(olderBooking.StartDate);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFilterByUserId_WhenUserIdProvided()
+    {
+        // Arrange
+        var targetUserId = fixture.Create<int>();
+        var otherUserId = fixture.Create<int>();
+
+        var targetUserBooking = CreateBookingReadModel(targetUserId, startDate: new DateTime(2024, 2, 15));
+        var otherUserBooking = CreateBookingReadModel(otherUserId, startDate: new DateTime(2024, 2, 20));
+
+        context.BookingReadModels.AddRange(targetUserBooking, otherUserBooking);
+        await context.SaveChangesAsync();
+
+        var query = new GetBookingsQuery(
+            UserId: targetUserId,
+            StartDate: null,
+            EndDate: null,
+            PageNumber: 1,
+            PageSize: 10
+        );
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(1);
+        result[0].UserId.Should().Be(targetUserId);
+        result[0].Id.Should().Be(targetUserBooking.Id);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnAllBookings_WhenUserIdIsNull()
+    {
+        // Arrange
+        var user1Id = fixture.Create<int>();
+        var user2Id = fixture.Create<int>();
+
+        var user1Booking = CreateBookingReadModel(user1Id, startDate: new DateTime(2024, 2, 15));
+        var user2Booking = CreateBookingReadModel(user2Id, startDate: new DateTime(2024, 2, 20));
+
+        context.BookingReadModels.AddRange(user1Booking, user2Booking);
+        await context.SaveChangesAsync();
+
+        var query = new GetBookingsQuery(
+            UserId: null, // Admin query - should see all bookings
+            StartDate: null,
+            EndDate: null,
+            PageNumber: 1,
+            PageSize: 10
+        );
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.Should().Contain(b => b.UserId == user1Id);
+        result.Should().Contain(b => b.UserId == user2Id);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFilterByStartDate_WhenStartDateProvided()
+    {
+        // Arrange
+        var userId = fixture.Create<int>();
+        var filterDate = new DateTime(2024, 3, 1);
+
+        var beforeFilterBooking = CreateBookingReadModel(userId, 
+            startDate: new DateTime(2024, 2, 15), 
+            endDate: new DateTime(2024, 2, 20)); // Ends before filter
+
+        var overlapFilterBooking = CreateBookingReadModel(userId,
+            startDate: new DateTime(2024, 2, 25),
+            endDate: new DateTime(2024, 3, 5)); // Ends after filter
+
+        var afterFilterBooking = CreateBookingReadModel(userId,
+            startDate: new DateTime(2024, 3, 10),
+            endDate: new DateTime(2024, 3, 15)); // Starts after filter
+
+        context.BookingReadModels.AddRange(beforeFilterBooking, overlapFilterBooking, afterFilterBooking);
+        await context.SaveChangesAsync();
+
+        var query = new GetBookingsQuery(
+            UserId: userId,
+            StartDate: filterDate,
+            EndDate: null,
+            PageNumber: 1,
+            PageSize: 10
+        );
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.Should().NotContain(b => b.Id == beforeFilterBooking.Id);
+        result.Should().Contain(b => b.Id == overlapFilterBooking.Id);
+        result.Should().Contain(b => b.Id == afterFilterBooking.Id);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFilterByEndDate_WhenEndDateProvided()
+    {
+        // Arrange
+        var userId = fixture.Create<int>();
+        var filterDate = new DateTime(2024, 3, 1);
+
+        var beforeFilterBooking = CreateBookingReadModel(userId,
+            startDate: new DateTime(2024, 2, 15),
+            endDate: new DateTime(2024, 2, 20)); // Starts and ends before filter
+
+        var overlapFilterBooking = CreateBookingReadModel(userId,
+            startDate: new DateTime(2024, 2, 25),
+            endDate: new DateTime(2024, 3, 5)); // Starts before filter
+
+        var afterFilterBooking = CreateBookingReadModel(userId,
+            startDate: new DateTime(2024, 3, 10),
+            endDate: new DateTime(2024, 3, 15)); // Starts after filter
+
+        context.BookingReadModels.AddRange(beforeFilterBooking, overlapFilterBooking, afterFilterBooking);
+        await context.SaveChangesAsync();
+
+        var query = new GetBookingsQuery(
+            UserId: userId,
+            StartDate: null,
+            EndDate: filterDate,
+            PageNumber: 1,
+            PageSize: 10
+        );
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.Should().Contain(b => b.Id == beforeFilterBooking.Id);
+        result.Should().Contain(b => b.Id == overlapFilterBooking.Id);
+        result.Should().NotContain(b => b.Id == afterFilterBooking.Id);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldSupportPagination()
+    {
+        // Arrange
+        var userId = fixture.Create<int>();
+        var bookings = new List<BookingReadModel>();
+
+        for (int i = 1; i <= 5; i++)
+        {
+            bookings.Add(CreateBookingReadModel(userId, startDate: new DateTime(2024, 1, i)));
+        }
+
+        context.BookingReadModels.AddRange(bookings);
+        await context.SaveChangesAsync();
+
+        var query = new GetBookingsQuery(
+            UserId: userId,
+            StartDate: null,
+            EndDate: null,
+            PageNumber: 2,
+            PageSize: 2
+        );
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(2);
+        // Should be sorted by StartDate descending, so page 2 (items 3-4) should be Jan 3 and Jan 2
+        result[0].StartDate.Should().Be(new DateTime(2024, 1, 3));
+        result[1].StartDate.Should().Be(new DateTime(2024, 1, 2));
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnEmptyList_WhenNoBookingsFound()
+    {
+        // Arrange
+        var userId = fixture.Create<int>();
+        var query = new GetBookingsQuery(
+            UserId: userId,
+            StartDate: null,
+            EndDate: null,
+            PageNumber: 1,
+            PageSize: 10
+        );
+
+        // Act
+        var result = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldMaintainSortOrderAcrossPages()
+    {
+        // Arrange
+        var userId = fixture.Create<int>();
+        var bookings = new List<BookingReadModel>();
+
+        // Create bookings with random order but predictable dates
+        var dates = new[]
+        {
+            new DateTime(2024, 5, 1), // Newest
+            new DateTime(2024, 4, 1),
+            new DateTime(2024, 3, 1),
+            new DateTime(2024, 2, 1),
+            new DateTime(2024, 1, 1)  // Oldest
+        };
+
+        foreach (var date in dates.Reverse()) // Add in reverse order to test sorting
+        {
+            bookings.Add(CreateBookingReadModel(userId, startDate: date));
+        }
+
+        context.BookingReadModels.AddRange(bookings);
+        await context.SaveChangesAsync();
+
+        var page1Query = new GetBookingsQuery(userId, null, null, 1, 2);
+        var page2Query = new GetBookingsQuery(userId, null, null, 2, 2);
+        var page3Query = new GetBookingsQuery(userId, null, null, 3, 2);
+
+        // Act
+        var page1 = await handler.Handle(page1Query, CancellationToken.None);
+        var page2 = await handler.Handle(page2Query, CancellationToken.None);
+        var page3 = await handler.Handle(page3Query, CancellationToken.None);
+
+        // Assert
+        page1.Should().HaveCount(2);
+        page1[0].StartDate.Should().Be(new DateTime(2024, 5, 1)); // Newest first
+        page1[1].StartDate.Should().Be(new DateTime(2024, 4, 1));
+
+        page2.Should().HaveCount(2);
+        page2[0].StartDate.Should().Be(new DateTime(2024, 3, 1));
+        page2[1].StartDate.Should().Be(new DateTime(2024, 2, 1));
+
+        page3.Should().HaveCount(1);
+        page3[0].StartDate.Should().Be(new DateTime(2024, 1, 1)); // Oldest last
+    }
+
+    private BookingReadModel CreateBookingReadModel(int userId, DateTime startDate, DateTime? endDate = null)
+    {
+        var actualEndDate = endDate ?? startDate.AddDays(2);
+        return new BookingReadModel
+        {
+            Id = fixture.Create<Guid>(),
+            UserId = userId,
+            StartDate = startDate,
+            EndDate = actualEndDate,
+            Status = fixture.Create<BookingStatus>(),
+            Notes = fixture.Create<string>(),
+            CreatedAt = fixture.Create<DateTime>(),
+            ChangedAt = fixture.Create<DateTime?>(),
+            LastEventVersion = fixture.Create<int>(),
+            BookingItemsJson = "[]",
+            UserName = fixture.Create<string>(),
+            UserEmail = fixture.Create<string>(),
+            TotalPersons = fixture.Create<int>()
+        };
+    }
+}

--- a/src/backend/Booking.Api.Tests/Unit/Features/Bookings/Queries/GetBookingsQueryHandlerTests.cs
+++ b/src/backend/Booking.Api.Tests/Unit/Features/Bookings/Queries/GetBookingsQueryHandlerTests.cs
@@ -36,7 +36,7 @@ public sealed class GetBookingsQueryHandlerTests : IDisposable
     }
 
     [Fact]
-    public async Task Handle_ShouldReturnBookingsSortedByStartDateDescending()
+    public async Task Handle_ShouldReturnBookingsSortedByStartDateAscending()
     {
         // Arrange
         var userId = fixture.Create<int>();
@@ -60,9 +60,9 @@ public sealed class GetBookingsQueryHandlerTests : IDisposable
 
         // Assert
         result.Should().HaveCount(3);
-        result[0].StartDate.Should().Be(newestBooking.StartDate);
+        result[0].StartDate.Should().Be(olderBooking.StartDate);
         result[1].StartDate.Should().Be(newerBooking.StartDate);
-        result[2].StartDate.Should().Be(olderBooking.StartDate);
+        result[2].StartDate.Should().Be(newestBooking.StartDate);
     }
 
     [Fact]
@@ -233,9 +233,9 @@ public sealed class GetBookingsQueryHandlerTests : IDisposable
 
         // Assert
         result.Should().HaveCount(2);
-        // Should be sorted by StartDate descending, so page 2 (items 3-4) should be Jan 3 and Jan 2
+        // Should be sorted by StartDate ascending, so page 2 (items 3-4) should be Jan 3 and Jan 4
         result[0].StartDate.Should().Be(new DateTime(2024, 1, 3));
-        result[1].StartDate.Should().Be(new DateTime(2024, 1, 2));
+        result[1].StartDate.Should().Be(new DateTime(2024, 1, 4));
     }
 
     [Fact]
@@ -294,15 +294,15 @@ public sealed class GetBookingsQueryHandlerTests : IDisposable
 
         // Assert
         page1.Should().HaveCount(2);
-        page1[0].StartDate.Should().Be(new DateTime(2024, 5, 1)); // Newest first
-        page1[1].StartDate.Should().Be(new DateTime(2024, 4, 1));
+        page1[0].StartDate.Should().Be(new DateTime(2024, 1, 1)); // Oldest first
+        page1[1].StartDate.Should().Be(new DateTime(2024, 2, 1));
 
         page2.Should().HaveCount(2);
         page2[0].StartDate.Should().Be(new DateTime(2024, 3, 1));
-        page2[1].StartDate.Should().Be(new DateTime(2024, 2, 1));
+        page2[1].StartDate.Should().Be(new DateTime(2024, 4, 1));
 
         page3.Should().HaveCount(1);
-        page3[0].StartDate.Should().Be(new DateTime(2024, 1, 1)); // Oldest last
+        page3[0].StartDate.Should().Be(new DateTime(2024, 5, 1)); // Newest last
     }
 
     private BookingReadModel CreateBookingReadModel(int userId, DateTime startDate, DateTime? endDate = null)

--- a/src/backend/Booking.Api.Tests/Unit/Features/Bookings/Queries/GetBookingsQueryHandlerTests.cs
+++ b/src/backend/Booking.Api.Tests/Unit/Features/Bookings/Queries/GetBookingsQueryHandlerTests.cs
@@ -47,13 +47,7 @@ public sealed class GetBookingsQueryHandlerTests : IDisposable
         context.BookingReadModels.AddRange(olderBooking, newerBooking, newestBooking);
         await context.SaveChangesAsync();
 
-        var query = new GetBookingsQuery(
-            UserId: userId,
-            StartDate: null,
-            EndDate: null,
-            PageNumber: 1,
-            PageSize: 10
-        );
+        var query = new GetBookingsQuery(UserId: userId);
 
         // Act
         var result = await handler.Handle(query, CancellationToken.None);
@@ -78,13 +72,7 @@ public sealed class GetBookingsQueryHandlerTests : IDisposable
         context.BookingReadModels.AddRange(targetUserBooking, otherUserBooking);
         await context.SaveChangesAsync();
 
-        var query = new GetBookingsQuery(
-            UserId: targetUserId,
-            StartDate: null,
-            EndDate: null,
-            PageNumber: 1,
-            PageSize: 10
-        );
+        var query = new GetBookingsQuery(UserId: targetUserId);
 
         // Act
         var result = await handler.Handle(query, CancellationToken.None);
@@ -108,13 +96,7 @@ public sealed class GetBookingsQueryHandlerTests : IDisposable
         context.BookingReadModels.AddRange(user1Booking, user2Booking);
         await context.SaveChangesAsync();
 
-        var query = new GetBookingsQuery(
-            UserId: null, // Admin query - should see all bookings
-            StartDate: null,
-            EndDate: null,
-            PageNumber: 1,
-            PageSize: 10
-        );
+        var query = new GetBookingsQuery(UserId: null); // Admin query - should see all bookings
 
         // Act
         var result = await handler.Handle(query, CancellationToken.None);
@@ -125,131 +107,13 @@ public sealed class GetBookingsQueryHandlerTests : IDisposable
         result.Should().Contain(b => b.UserId == user2Id);
     }
 
-    [Fact]
-    public async Task Handle_ShouldFilterByStartDate_WhenStartDateProvided()
-    {
-        // Arrange
-        var userId = fixture.Create<int>();
-        var filterDate = new DateTime(2024, 3, 1);
-
-        var beforeFilterBooking = CreateBookingReadModel(userId, 
-            startDate: new DateTime(2024, 2, 15), 
-            endDate: new DateTime(2024, 2, 20)); // Ends before filter
-
-        var overlapFilterBooking = CreateBookingReadModel(userId,
-            startDate: new DateTime(2024, 2, 25),
-            endDate: new DateTime(2024, 3, 5)); // Ends after filter
-
-        var afterFilterBooking = CreateBookingReadModel(userId,
-            startDate: new DateTime(2024, 3, 10),
-            endDate: new DateTime(2024, 3, 15)); // Starts after filter
-
-        context.BookingReadModels.AddRange(beforeFilterBooking, overlapFilterBooking, afterFilterBooking);
-        await context.SaveChangesAsync();
-
-        var query = new GetBookingsQuery(
-            UserId: userId,
-            StartDate: filterDate,
-            EndDate: null,
-            PageNumber: 1,
-            PageSize: 10
-        );
-
-        // Act
-        var result = await handler.Handle(query, CancellationToken.None);
-
-        // Assert
-        result.Should().HaveCount(2);
-        result.Should().NotContain(b => b.Id == beforeFilterBooking.Id);
-        result.Should().Contain(b => b.Id == overlapFilterBooking.Id);
-        result.Should().Contain(b => b.Id == afterFilterBooking.Id);
-    }
-
-    [Fact]
-    public async Task Handle_ShouldFilterByEndDate_WhenEndDateProvided()
-    {
-        // Arrange
-        var userId = fixture.Create<int>();
-        var filterDate = new DateTime(2024, 3, 1);
-
-        var beforeFilterBooking = CreateBookingReadModel(userId,
-            startDate: new DateTime(2024, 2, 15),
-            endDate: new DateTime(2024, 2, 20)); // Starts and ends before filter
-
-        var overlapFilterBooking = CreateBookingReadModel(userId,
-            startDate: new DateTime(2024, 2, 25),
-            endDate: new DateTime(2024, 3, 5)); // Starts before filter
-
-        var afterFilterBooking = CreateBookingReadModel(userId,
-            startDate: new DateTime(2024, 3, 10),
-            endDate: new DateTime(2024, 3, 15)); // Starts after filter
-
-        context.BookingReadModels.AddRange(beforeFilterBooking, overlapFilterBooking, afterFilterBooking);
-        await context.SaveChangesAsync();
-
-        var query = new GetBookingsQuery(
-            UserId: userId,
-            StartDate: null,
-            EndDate: filterDate,
-            PageNumber: 1,
-            PageSize: 10
-        );
-
-        // Act
-        var result = await handler.Handle(query, CancellationToken.None);
-
-        // Assert
-        result.Should().HaveCount(2);
-        result.Should().Contain(b => b.Id == beforeFilterBooking.Id);
-        result.Should().Contain(b => b.Id == overlapFilterBooking.Id);
-        result.Should().NotContain(b => b.Id == afterFilterBooking.Id);
-    }
-
-    [Fact]
-    public async Task Handle_ShouldSupportPagination()
-    {
-        // Arrange
-        var userId = fixture.Create<int>();
-        var bookings = new List<BookingReadModel>();
-
-        for (int i = 1; i <= 5; i++)
-        {
-            bookings.Add(CreateBookingReadModel(userId, startDate: new DateTime(2024, 1, i)));
-        }
-
-        context.BookingReadModels.AddRange(bookings);
-        await context.SaveChangesAsync();
-
-        var query = new GetBookingsQuery(
-            UserId: userId,
-            StartDate: null,
-            EndDate: null,
-            PageNumber: 2,
-            PageSize: 2
-        );
-
-        // Act
-        var result = await handler.Handle(query, CancellationToken.None);
-
-        // Assert
-        result.Should().HaveCount(2);
-        // Should be sorted by StartDate ascending, so page 2 (items 3-4) should be Jan 3 and Jan 4
-        result[0].StartDate.Should().Be(new DateTime(2024, 1, 3));
-        result[1].StartDate.Should().Be(new DateTime(2024, 1, 4));
-    }
 
     [Fact]
     public async Task Handle_ShouldReturnEmptyList_WhenNoBookingsFound()
     {
         // Arrange
         var userId = fixture.Create<int>();
-        var query = new GetBookingsQuery(
-            UserId: userId,
-            StartDate: null,
-            EndDate: null,
-            PageNumber: 1,
-            PageSize: 10
-        );
+        var query = new GetBookingsQuery(UserId: userId);
 
         // Act
         var result = await handler.Handle(query, CancellationToken.None);
@@ -258,52 +122,6 @@ public sealed class GetBookingsQueryHandlerTests : IDisposable
         result.Should().BeEmpty();
     }
 
-    [Fact]
-    public async Task Handle_ShouldMaintainSortOrderAcrossPages()
-    {
-        // Arrange
-        var userId = fixture.Create<int>();
-        var bookings = new List<BookingReadModel>();
-
-        // Create bookings with random order but predictable dates
-        var dates = new[]
-        {
-            new DateTime(2024, 5, 1), // Newest
-            new DateTime(2024, 4, 1),
-            new DateTime(2024, 3, 1),
-            new DateTime(2024, 2, 1),
-            new DateTime(2024, 1, 1)  // Oldest
-        };
-
-        foreach (var date in dates.Reverse()) // Add in reverse order to test sorting
-        {
-            bookings.Add(CreateBookingReadModel(userId, startDate: date));
-        }
-
-        context.BookingReadModels.AddRange(bookings);
-        await context.SaveChangesAsync();
-
-        var page1Query = new GetBookingsQuery(userId, null, null, 1, 2);
-        var page2Query = new GetBookingsQuery(userId, null, null, 2, 2);
-        var page3Query = new GetBookingsQuery(userId, null, null, 3, 2);
-
-        // Act
-        var page1 = await handler.Handle(page1Query, CancellationToken.None);
-        var page2 = await handler.Handle(page2Query, CancellationToken.None);
-        var page3 = await handler.Handle(page3Query, CancellationToken.None);
-
-        // Assert
-        page1.Should().HaveCount(2);
-        page1[0].StartDate.Should().Be(new DateTime(2024, 1, 1)); // Oldest first
-        page1[1].StartDate.Should().Be(new DateTime(2024, 2, 1));
-
-        page2.Should().HaveCount(2);
-        page2[0].StartDate.Should().Be(new DateTime(2024, 3, 1));
-        page2[1].StartDate.Should().Be(new DateTime(2024, 4, 1));
-
-        page3.Should().HaveCount(1);
-        page3[0].StartDate.Should().Be(new DateTime(2024, 5, 1)); // Newest last
-    }
 
     private BookingReadModel CreateBookingReadModel(int userId, DateTime startDate, DateTime? endDate = null)
     {

--- a/src/backend/Booking.Api/Controllers/BookingsController.cs
+++ b/src/backend/Booking.Api/Controllers/BookingsController.cs
@@ -17,21 +17,13 @@ namespace Booking.Api.Controllers;
 public class BookingsController(IMediator mediator) : ControllerBase
 {
     [HttpGet]
-    public async Task<ActionResult<List<BookingDto>>> GetBookings(
-        [FromQuery] DateTime? startDate = null,
-        [FromQuery] DateTime? endDate = null,
-        [FromQuery] int pageNumber = 1,
-        [FromQuery] int pageSize = 20)
+    public async Task<ActionResult<List<BookingDto>>> GetBookings()
     {
         var userId = GetCurrentUserId();
         var isAdmin = User.IsInRole("Administrator");
         
         var query = new GetBookingsQuery(
-            UserId: isAdmin ? null : userId, // Admins can see all bookings
-            StartDate: startDate,
-            EndDate: endDate,
-            PageNumber: pageNumber,
-            PageSize: pageSize
+            UserId: isAdmin ? null : userId // Admins can see all bookings
         );
         
         var result = await mediator.Send(query);

--- a/src/backend/Booking.Api/Features/Bookings/Queries/GetBookingsQuery.cs
+++ b/src/backend/Booking.Api/Features/Bookings/Queries/GetBookingsQuery.cs
@@ -44,7 +44,7 @@ public class GetBookingsQueryHandler(
         }
 
         var bookings = await query
-            .OrderByDescending(b => b.CreatedAt)
+            .OrderByDescending(b => b.StartDate)
             .Skip((request.PageNumber - 1) * request.PageSize)
             .Take(request.PageSize)
             .ToListAsync(cancellationToken);

--- a/src/backend/Booking.Api/Features/Bookings/Queries/GetBookingsQuery.cs
+++ b/src/backend/Booking.Api/Features/Bookings/Queries/GetBookingsQuery.cs
@@ -9,11 +9,7 @@ using Booking.Api.Domain.ValueObjects;
 namespace Booking.Api.Features.Bookings.Queries;
 
 public record GetBookingsQuery(
-    int? UserId = null,
-    DateTime? StartDate = null,
-    DateTime? EndDate = null,
-    int PageNumber = 1,
-    int PageSize = 20
+    int? UserId = null
 ) : IRequest<List<BookingDto>>;
 
 public class GetBookingsQueryHandler(
@@ -23,8 +19,7 @@ public class GetBookingsQueryHandler(
 {
     public async Task<List<BookingDto>> Handle(GetBookingsQuery request, CancellationToken cancellationToken)
     {
-        logger.LogInformation("Getting bookings for user {UserId}, date range {StartDate} - {EndDate}",
-            request.UserId, request.StartDate, request.EndDate);
+        logger.LogInformation("Getting bookings for user {UserId}", request.UserId);
 
         var query = context.BookingReadModels.AsQueryable();
 
@@ -33,20 +28,8 @@ public class GetBookingsQueryHandler(
             query = query.Where(b => b.UserId == request.UserId.Value);
         }
 
-        if (request.StartDate.HasValue)
-        {
-            query = query.Where(b => b.EndDate >= request.StartDate.Value);
-        }
-
-        if (request.EndDate.HasValue)
-        {
-            query = query.Where(b => b.StartDate <= request.EndDate.Value);
-        }
-
         var bookings = await query
             .OrderBy(b => b.StartDate)
-            .Skip((request.PageNumber - 1) * request.PageSize)
-            .Take(request.PageSize)
             .ToListAsync(cancellationToken);
 
         return bookings.Select(MapToDto).ToList();

--- a/src/backend/Booking.Api/Features/Bookings/Queries/GetBookingsQuery.cs
+++ b/src/backend/Booking.Api/Features/Bookings/Queries/GetBookingsQuery.cs
@@ -44,7 +44,7 @@ public class GetBookingsQueryHandler(
         }
 
         var bookings = await query
-            .OrderByDescending(b => b.StartDate)
+            .OrderBy(b => b.StartDate)
             .Skip((request.PageNumber - 1) * request.PageSize)
             .Take(request.PageSize)
             .ToListAsync(cancellationToken);

--- a/src/frontend/app/bookings/__tests__/BookingCard.test.tsx
+++ b/src/frontend/app/bookings/__tests__/BookingCard.test.tsx
@@ -1,0 +1,384 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Booking, BookingStatus } from '../../../lib/types/api';
+
+// Import the component by reading the page file and extracting just the BookingCard part
+const mockBooking: Booking = {
+  id: '123e4567-e89b-12d3-a456-426614174000',
+  userId: 1,
+  userName: 'Test User',
+  userEmail: 'test@example.com',
+  startDate: '2024-03-15T00:00:00Z',
+  endDate: '2024-03-17T00:00:00Z',
+  numberOfNights: 2,
+  totalPersons: 4,
+  status: BookingStatus.Confirmed,
+  bookingItems: [
+    {
+      sleepingAccommodationId: '456e7890-e89b-12d3-a456-426614174001',
+      sleepingAccommodationName: 'Hauptschlafzimmer',
+      personCount: 2,
+    },
+    {
+      sleepingAccommodationId: '789e1234-e89b-12d3-a456-426614174002', 
+      sleepingAccommodationName: 'Gästezimmer',
+      personCount: 2,
+    },
+  ],
+  notes: 'Test notes',
+  createdAt: '2024-03-01T10:00:00Z',
+  changedAt: '2024-03-02T15:30:00Z',
+};
+
+// Mock BookingCard component (extracted from page.tsx)
+interface BookingCardProps {
+  booking: Booking;
+  onClick: () => void;
+}
+
+function BookingCard({ booking, onClick }: BookingCardProps) {
+  const getStatusBadge = (status: BookingStatus) => {
+    switch (status) {
+      case BookingStatus.Pending:
+        return (
+          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
+            <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            Ausstehend
+          </span>
+        );
+      case BookingStatus.Confirmed:
+        return (
+          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+            <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+            </svg>
+            Bestätigt
+          </span>
+        );
+      case BookingStatus.Cancelled:
+        return (
+          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">
+            <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+            Storniert
+          </span>
+        );
+      case BookingStatus.Completed:
+        return (
+          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+            <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            Abgeschlossen
+          </span>
+        );
+      default:
+        return (
+          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
+            Unbekannt
+          </span>
+        );
+    }
+  };
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString('de-DE', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric'
+    });
+  };
+
+  return (
+    <div
+      className="bg-white rounded-2xl shadow-xl hover:shadow-2xl transition-all duration-300 overflow-hidden cursor-pointer transform hover:scale-[1.02]"
+      onClick={onClick}
+    >
+      <div className="p-6">
+        {/* Booking Header */}
+        <div className="flex items-start justify-between mb-4">
+          <div className="flex-1">
+            <div className="flex items-center space-x-3 mb-2">
+              <h3 className="text-lg font-semibold text-gray-900">
+                {formatDate(booking.startDate)} - {formatDate(booking.endDate)}
+              </h3>
+              {getStatusBadge(booking.status)}
+            </div>
+            <p className="text-sm text-gray-600">
+              Buchungs-ID: {booking.id.slice(0, 8)}...
+            </p>
+          </div>
+        </div>
+
+        {/* Booking Details */}
+        <div className="grid grid-cols-2 gap-4 mb-4">
+          <div className="flex items-center text-sm text-gray-600">
+            <svg className="w-4 h-4 mr-2 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+            </svg>
+            <span>{booking.numberOfNights} {booking.numberOfNights === 1 ? 'Nacht' : 'Nächte'}</span>
+          </div>
+          <div className="flex items-center text-sm text-gray-600">
+            <svg className="w-4 h-4 mr-2 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+            </svg>
+            <span>{booking.totalPersons} {booking.totalPersons === 1 ? 'Person' : 'Personen'}</span>
+          </div>
+        </div>
+
+        {/* Accommodations */}
+        <div className="space-y-2">
+          <p className="text-sm font-medium text-gray-700">Schlafmöglichkeiten:</p>
+          <div className="space-y-1">
+            {booking.bookingItems.map((item, index) => (
+              <div key={index} className="flex items-center justify-between text-sm bg-gray-50 rounded-lg px-3 py-2">
+                <span className="text-gray-900">{item.sleepingAccommodationName}</span>
+                <span className="text-gray-600">{item.personCount} {item.personCount === 1 ? 'Person' : 'Personen'}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Notes */}
+        {booking.notes && (
+          <div className="mt-4 p-3 bg-blue-50 rounded-lg">
+            <p className="text-sm text-blue-800">
+              <span className="font-medium">Notizen:</span> {booking.notes}
+            </p>
+          </div>
+        )}
+
+        {/* Creation Date */}
+        <div className="mt-4 pt-4 border-t border-gray-200">
+          <p className="text-xs text-gray-500">
+            Erstellt am {formatDate(booking.createdAt)}
+            {booking.changedAt && ` • Zuletzt geändert am ${formatDate(booking.changedAt)}`}
+          </p>
+        </div>
+      </div>
+
+      {/* Action Button */}
+      <div className="bg-gray-50 px-6 py-3">
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-gray-600">Details anzeigen</span>
+          <svg className="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+describe('BookingCard', () => {
+  const mockOnClick = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('should display booking date range', () => {
+      render(<BookingCard booking={mockBooking} onClick={mockOnClick} />);
+      
+      expect(screen.getByText('15.03.2024 - 17.03.2024')).toBeInTheDocument();
+    });
+
+    it('should display booking ID (truncated)', () => {
+      render(<BookingCard booking={mockBooking} onClick={mockOnClick} />);
+      
+      expect(screen.getByText('Buchungs-ID: 123e4567...')).toBeInTheDocument();
+    });
+
+    it('should display number of nights correctly (plural)', () => {
+      render(<BookingCard booking={mockBooking} onClick={mockOnClick} />);
+      
+      expect(screen.getByText('2 Nächte')).toBeInTheDocument();
+    });
+
+    it('should display number of nights correctly (singular)', () => {
+      const singleNightBooking = { ...mockBooking, numberOfNights: 1 };
+      render(<BookingCard booking={singleNightBooking} onClick={mockOnClick} />);
+      
+      expect(screen.getByText('1 Nacht')).toBeInTheDocument();
+    });
+
+    it('should display total persons correctly (plural)', () => {
+      render(<BookingCard booking={mockBooking} onClick={mockOnClick} />);
+      
+      expect(screen.getByText('4 Personen')).toBeInTheDocument();
+    });
+
+    it('should display total persons correctly (singular)', () => {
+      const singlePersonBooking = { ...mockBooking, totalPersons: 1 };
+      render(<BookingCard booking={singlePersonBooking} onClick={mockOnClick} />);
+      
+      expect(screen.getByText('1 Person')).toBeInTheDocument();
+    });
+
+    it('should display accommodation items', () => {
+      render(<BookingCard booking={mockBooking} onClick={mockOnClick} />);
+      
+      expect(screen.getByText('Hauptschlafzimmer')).toBeInTheDocument();
+      expect(screen.getByText('Gästezimmer')).toBeInTheDocument();
+      expect(screen.getAllByText('2 Personen')).toHaveLength(2); // 2 accommodations only
+    });
+
+    it('should display notes when present', () => {
+      render(<BookingCard booking={mockBooking} onClick={mockOnClick} />);
+      
+      expect(screen.getByText('Notizen:')).toBeInTheDocument();
+      expect(screen.getByText('Test notes')).toBeInTheDocument();
+    });
+
+    it('should not display notes when not present', () => {
+      const bookingWithoutNotes = { ...mockBooking, notes: undefined };
+      render(<BookingCard booking={bookingWithoutNotes} onClick={mockOnClick} />);
+      
+      expect(screen.queryByText('Notizen:')).not.toBeInTheDocument();
+    });
+
+    it('should display creation date', () => {
+      render(<BookingCard booking={mockBooking} onClick={mockOnClick} />);
+      
+      expect(screen.getByText(/Erstellt am 01\.03\.2024/)).toBeInTheDocument();
+    });
+
+    it('should display changed date when present', () => {
+      render(<BookingCard booking={mockBooking} onClick={mockOnClick} />);
+      
+      expect(screen.getByText(/Zuletzt geändert am 02\.03\.2024/)).toBeInTheDocument();
+    });
+
+    it('should not display changed date when not present', () => {
+      const bookingWithoutChangedAt = { ...mockBooking, changedAt: undefined };
+      render(<BookingCard booking={bookingWithoutChangedAt} onClick={mockOnClick} />);
+      
+      expect(screen.queryByText(/Zuletzt geändert/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Status Badges', () => {
+    it('should display pending status badge', () => {
+      const pendingBooking = { ...mockBooking, status: BookingStatus.Pending };
+      render(<BookingCard booking={pendingBooking} onClick={mockOnClick} />);
+      
+      const badge = screen.getByText('Ausstehend');
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveClass('bg-yellow-100', 'text-yellow-800');
+    });
+
+    it('should display confirmed status badge', () => {
+      render(<BookingCard booking={mockBooking} onClick={mockOnClick} />);
+      
+      const badge = screen.getByText('Bestätigt');
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveClass('bg-green-100', 'text-green-800');
+    });
+
+    it('should display cancelled status badge', () => {
+      const cancelledBooking = { ...mockBooking, status: BookingStatus.Cancelled };
+      render(<BookingCard booking={cancelledBooking} onClick={mockOnClick} />);
+      
+      const badge = screen.getByText('Storniert');
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveClass('bg-red-100', 'text-red-800');
+    });
+
+    it('should display completed status badge', () => {
+      const completedBooking = { ...mockBooking, status: BookingStatus.Completed };
+      render(<BookingCard booking={completedBooking} onClick={mockOnClick} />);
+      
+      const badge = screen.getByText('Abgeschlossen');
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveClass('bg-blue-100', 'text-blue-800');
+    });
+
+    it('should display unknown status badge for invalid status', () => {
+      const unknownBooking = { ...mockBooking, status: 'Invalid' as BookingStatus };
+      render(<BookingCard booking={unknownBooking} onClick={mockOnClick} />);
+      
+      const badge = screen.getByText('Unbekannt');
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveClass('bg-gray-100', 'text-gray-800');
+    });
+  });
+
+  describe('Interaction', () => {
+    it('should call onClick when card is clicked', () => {
+      render(<BookingCard booking={mockBooking} onClick={mockOnClick} />);
+      
+      const card = screen.getByText('15.03.2024 - 17.03.2024').closest('div');
+      fireEvent.click(card!);
+      
+      expect(mockOnClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('should have cursor-pointer class', () => {
+      const { container } = render(<BookingCard booking={mockBooking} onClick={mockOnClick} />);
+      
+      const card = container.querySelector('.cursor-pointer');
+      expect(card).toBeInTheDocument();
+    });
+
+    it('should have hover effects', () => {
+      const { container } = render(<BookingCard booking={mockBooking} onClick={mockOnClick} />);
+      
+      const card = container.querySelector('.hover\\:shadow-2xl');
+      expect(card).toBeInTheDocument();
+      expect(card).toHaveClass('hover:scale-[1.02]');
+    });
+  });
+
+  describe('Visual Design', () => {
+    it('should have proper card styling', () => {
+      const { container } = render(<BookingCard booking={mockBooking} onClick={mockOnClick} />);
+      
+      const card = container.firstChild as HTMLElement;
+      expect(card).toHaveClass('bg-white', 'rounded-2xl', 'shadow-xl');
+    });
+
+    it('should display action section at bottom', () => {
+      render(<BookingCard booking={mockBooking} onClick={mockOnClick} />);
+      
+      expect(screen.getByText('Details anzeigen')).toBeInTheDocument();
+    });
+
+    it('should have correct icons for nights and persons', () => {
+      const { container } = render(<BookingCard booking={mockBooking} onClick={mockOnClick} />);
+      
+      // Check for SVG icons
+      const svgIcons = container.querySelectorAll('svg');
+      expect(svgIcons.length).toBeGreaterThan(2); // Status badge + nights + persons + action icons
+    });
+  });
+
+  describe('Date Formatting', () => {
+    it('should format dates in German locale', () => {
+      render(<BookingCard booking={mockBooking} onClick={mockOnClick} />);
+      
+      // Check German date format (DD.MM.YYYY)
+      expect(screen.getByText('15.03.2024 - 17.03.2024')).toBeInTheDocument();
+      expect(screen.getByText(/01\.03\.2024/)).toBeInTheDocument();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should have proper heading hierarchy', () => {
+      render(<BookingCard booking={mockBooking} onClick={mockOnClick} />);
+      
+      const heading = screen.getByRole('heading', { name: /15\.03\.2024 - 17\.03\.2024/ });
+      expect(heading).toBeInTheDocument();
+      expect(heading.tagName).toBe('H3');
+    });
+
+    it('should have proper text contrast', () => {
+      render(<BookingCard booking={mockBooking} onClick={mockOnClick} />);
+      
+      const accommodationText = screen.getByText('Hauptschlafzimmer');
+      expect(accommodationText).toHaveClass('text-gray-900');
+    });
+  });
+});

--- a/src/frontend/app/bookings/__tests__/BookingCard.test.tsx
+++ b/src/frontend/app/bookings/__tests__/BookingCard.test.tsx
@@ -106,9 +106,6 @@ function BookingCard({ booking, onClick }: BookingCardProps) {
               </h3>
               {getStatusBadge(booking.status)}
             </div>
-            <p className="text-sm text-gray-600">
-              Buchungs-ID: {booking.id.slice(0, 8)}...
-            </p>
           </div>
         </div>
 
@@ -134,22 +131,6 @@ function BookingCard({ booking, onClick }: BookingCardProps) {
           </div>
         </div>
 
-        {/* Notes */}
-        {booking.notes && (
-          <div className="mt-4 p-3 bg-blue-50 rounded-lg">
-            <p className="text-sm text-blue-800">
-              <span className="font-medium">Notizen:</span> {booking.notes}
-            </p>
-          </div>
-        )}
-
-        {/* Creation Date */}
-        <div className="mt-4 pt-4 border-t border-gray-200">
-          <p className="text-xs text-gray-500">
-            Erstellt am {formatDate(booking.createdAt)}
-            {booking.changedAt && ` • Zuletzt geändert am ${formatDate(booking.changedAt)}`}
-          </p>
-        </div>
       </div>
 
       {/* Action Button */}
@@ -179,11 +160,6 @@ describe('BookingCard', () => {
       expect(screen.getByText('15.03.2024 - 17.03.2024')).toBeInTheDocument();
     });
 
-    it('should display booking ID (truncated)', () => {
-      render(<BookingCard booking={mockBooking} onClick={mockOnClick} />);
-      
-      expect(screen.getByText('Buchungs-ID: 123e4567...')).toBeInTheDocument();
-    });
 
     it('should display number of nights correctly (plural)', () => {
       render(<BookingCard booking={mockBooking} onClick={mockOnClick} />);
@@ -227,38 +203,6 @@ describe('BookingCard', () => {
       expect(screen.getByText('1 Schlafmöglichkeit')).toBeInTheDocument();
     });
 
-    it('should display notes when present', () => {
-      render(<BookingCard booking={mockBooking} onClick={mockOnClick} />);
-      
-      expect(screen.getByText('Notizen:')).toBeInTheDocument();
-      expect(screen.getByText('Test notes')).toBeInTheDocument();
-    });
-
-    it('should not display notes when not present', () => {
-      const bookingWithoutNotes = { ...mockBooking, notes: undefined };
-      render(<BookingCard booking={bookingWithoutNotes} onClick={mockOnClick} />);
-      
-      expect(screen.queryByText('Notizen:')).not.toBeInTheDocument();
-    });
-
-    it('should display creation date', () => {
-      render(<BookingCard booking={mockBooking} onClick={mockOnClick} />);
-      
-      expect(screen.getByText(/Erstellt am 01\.03\.2024/)).toBeInTheDocument();
-    });
-
-    it('should display changed date when present', () => {
-      render(<BookingCard booking={mockBooking} onClick={mockOnClick} />);
-      
-      expect(screen.getByText(/Zuletzt geändert am 02\.03\.2024/)).toBeInTheDocument();
-    });
-
-    it('should not display changed date when not present', () => {
-      const bookingWithoutChangedAt = { ...mockBooking, changedAt: undefined };
-      render(<BookingCard booking={bookingWithoutChangedAt} onClick={mockOnClick} />);
-      
-      expect(screen.queryByText(/Zuletzt geändert/)).not.toBeInTheDocument();
-    });
   });
 
   describe('Status Badges', () => {
@@ -360,9 +304,8 @@ describe('BookingCard', () => {
     it('should format dates in German locale', () => {
       render(<BookingCard booking={mockBooking} onClick={mockOnClick} />);
       
-      // Check German date format (DD.MM.YYYY)
+      // Check German date format (DD.MM.YYYY) for booking dates
       expect(screen.getByText('15.03.2024 - 17.03.2024')).toBeInTheDocument();
-      expect(screen.getByText(/01\.03\.2024/)).toBeInTheDocument();
     });
   });
 

--- a/src/frontend/app/bookings/__tests__/BookingCard.test.tsx
+++ b/src/frontend/app/bookings/__tests__/BookingCard.test.tsx
@@ -113,10 +113,10 @@ function BookingCard({ booking, onClick }: BookingCardProps) {
         </div>
 
         {/* Booking Details */}
-        <div className="grid grid-cols-2 gap-4 mb-4">
+        <div className="grid grid-cols-3 gap-4 mb-4">
           <div className="flex items-center text-sm text-gray-600">
             <svg className="w-4 h-4 mr-2 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 718.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
             </svg>
             <span>{booking.numberOfNights} {booking.numberOfNights === 1 ? 'Nacht' : 'Nächte'}</span>
           </div>
@@ -126,18 +126,11 @@ function BookingCard({ booking, onClick }: BookingCardProps) {
             </svg>
             <span>{booking.totalPersons} {booking.totalPersons === 1 ? 'Person' : 'Personen'}</span>
           </div>
-        </div>
-
-        {/* Accommodations */}
-        <div className="space-y-2">
-          <p className="text-sm font-medium text-gray-700">Schlafmöglichkeiten:</p>
-          <div className="space-y-1">
-            {booking.bookingItems.map((item, index) => (
-              <div key={index} className="flex items-center justify-between text-sm bg-gray-50 rounded-lg px-3 py-2">
-                <span className="text-gray-900">{item.sleepingAccommodationName}</span>
-                <span className="text-gray-600">{item.personCount} {item.personCount === 1 ? 'Person' : 'Personen'}</span>
-              </div>
-            ))}
+          <div className="flex items-center text-sm text-gray-600">
+            <svg className="w-4 h-4 mr-2 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2-2v16m14 0V9a2 2 0 00-2-2H9a2 2 0 00-2-2v12a2 2 0 002 2h10a2 2 0 002-2z" />
+            </svg>
+            <span>{booking.bookingItems.length} {booking.bookingItems.length === 1 ? 'Schlafmöglichkeit' : 'Schlafmöglichkeiten'}</span>
           </div>
         </div>
 
@@ -218,12 +211,20 @@ describe('BookingCard', () => {
       expect(screen.getByText('1 Person')).toBeInTheDocument();
     });
 
-    it('should display accommodation items', () => {
+    it('should display accommodation count (plural)', () => {
       render(<BookingCard booking={mockBooking} onClick={mockOnClick} />);
       
-      expect(screen.getByText('Hauptschlafzimmer')).toBeInTheDocument();
-      expect(screen.getByText('Gästezimmer')).toBeInTheDocument();
-      expect(screen.getAllByText('2 Personen')).toHaveLength(2); // 2 accommodations only
+      expect(screen.getByText('2 Schlafmöglichkeiten')).toBeInTheDocument();
+    });
+
+    it('should display accommodation count (singular)', () => {
+      const singleAccommodationBooking = {
+        ...mockBooking,
+        bookingItems: [mockBooking.bookingItems[0]],
+      };
+      render(<BookingCard booking={singleAccommodationBooking} onClick={mockOnClick} />);
+      
+      expect(screen.getByText('1 Schlafmöglichkeit')).toBeInTheDocument();
     });
 
     it('should display notes when present', () => {
@@ -346,12 +347,12 @@ describe('BookingCard', () => {
       expect(screen.getByText('Details anzeigen')).toBeInTheDocument();
     });
 
-    it('should have correct icons for nights and persons', () => {
+    it('should have correct icons for all booking details', () => {
       const { container } = render(<BookingCard booking={mockBooking} onClick={mockOnClick} />);
       
-      // Check for SVG icons
+      // Check for SVG icons (status badge + nights + persons + accommodations + action icon)
       const svgIcons = container.querySelectorAll('svg');
-      expect(svgIcons.length).toBeGreaterThan(2); // Status badge + nights + persons + action icons
+      expect(svgIcons.length).toBeGreaterThan(3); // Status badge + nights + persons + accommodations + action icons
     });
   });
 
@@ -377,8 +378,8 @@ describe('BookingCard', () => {
     it('should have proper text contrast', () => {
       render(<BookingCard booking={mockBooking} onClick={mockOnClick} />);
       
-      const accommodationText = screen.getByText('Hauptschlafzimmer');
-      expect(accommodationText).toHaveClass('text-gray-900');
+      const dateText = screen.getByText('15.03.2024 - 17.03.2024');
+      expect(dateText).toHaveClass('text-gray-900');
     });
   });
 });

--- a/src/frontend/app/bookings/__tests__/BookingsPage.test.tsx
+++ b/src/frontend/app/bookings/__tests__/BookingsPage.test.tsx
@@ -210,28 +210,28 @@ describe('BookingsPage', () => {
       expect(screen.getByText('Verwalten Sie Ihre Garten-Buchungen')).toBeInTheDocument();
     });
 
-    it('should sort bookings by start date (newest first)', async () => {
-      // Test with the default mockBookings which have March (2024-03-15) and April (2024-04-01)
-      // After sorting, April should come first (newest first)
+    it('should display bookings in the order returned by API', async () => {
+      // Note: Sorting should be handled by the backend API, not client-side
+      // This test verifies that bookings are displayed as returned from the API
       render(<BookingsPage />);
       
       await waitFor(() => {
-        expect(screen.getByText('01.04.2024 - 03.04.2024')).toBeInTheDocument(); // April booking (should be first due to sorting)
+        expect(screen.getByText('15.03.2024 - 17.03.2024')).toBeInTheDocument(); // First booking from mockBookings
       });
       
       // Check that API was called and both bookings are displayed
       expect(apiClient.getBookings).toHaveBeenCalled();
-      expect(screen.getByText('15.03.2024 - 17.03.2024')).toBeInTheDocument(); // March booking (should be second)
+      expect(screen.getByText('01.04.2024 - 03.04.2024')).toBeInTheDocument(); // Second booking from mockBookings
     });
 
     it('should display booking cards', async () => {
       render(<BookingsPage />);
       
       await waitFor(() => {
-        expect(screen.getByText('01.04.2024 - 03.04.2024')).toBeInTheDocument();
+        expect(screen.getByText('15.03.2024 - 17.03.2024')).toBeInTheDocument();
       });
       
-      expect(screen.getByText('15.03.2024 - 17.03.2024')).toBeInTheDocument();
+      expect(screen.getByText('01.04.2024 - 03.04.2024')).toBeInTheDocument();
       expect(screen.getByText('Bestätigt')).toBeInTheDocument();
       expect(screen.getByText('Ausstehend')).toBeInTheDocument();
     });
@@ -251,14 +251,14 @@ describe('BookingsPage', () => {
       render(<BookingsPage />);
       
       await waitFor(() => {
-        expect(screen.getByText('01.04.2024 - 03.04.2024')).toBeInTheDocument();
+        expect(screen.getByText('15.03.2024 - 17.03.2024')).toBeInTheDocument();
       });
       
-      const bookingCard = screen.getByText('01.04.2024 - 03.04.2024').closest('div');
+      const bookingCard = screen.getByText('15.03.2024 - 17.03.2024').closest('div');
       fireEvent.click(bookingCard!);
       
-      // We clicked on the April booking (01.04.2024), which should navigate to that booking's ID
-      expect(mockRouter.push).toHaveBeenCalledWith('/bookings/987e6543-e89b-12d3-a456-426614174001');
+      // We clicked on the March booking (15.03.2024), which should navigate to that booking's ID
+      expect(mockRouter.push).toHaveBeenCalledWith('/bookings/123e4567-e89b-12d3-a456-426614174000');
     });
   });
 

--- a/src/frontend/app/bookings/__tests__/BookingsPage.test.tsx
+++ b/src/frontend/app/bookings/__tests__/BookingsPage.test.tsx
@@ -210,14 +210,28 @@ describe('BookingsPage', () => {
       expect(screen.getByText('Verwalten Sie Ihre Garten-Buchungen')).toBeInTheDocument();
     });
 
+    it('should sort bookings by start date (newest first)', async () => {
+      // Test with the default mockBookings which have March (2024-03-15) and April (2024-04-01)
+      // After sorting, April should come first (newest first)
+      render(<BookingsPage />);
+      
+      await waitFor(() => {
+        expect(screen.getByText('01.04.2024 - 03.04.2024')).toBeInTheDocument(); // April booking (should be first due to sorting)
+      });
+      
+      // Check that API was called and both bookings are displayed
+      expect(apiClient.getBookings).toHaveBeenCalled();
+      expect(screen.getByText('15.03.2024 - 17.03.2024')).toBeInTheDocument(); // March booking (should be second)
+    });
+
     it('should display booking cards', async () => {
       render(<BookingsPage />);
       
       await waitFor(() => {
-        expect(screen.getByText('15.03.2024 - 17.03.2024')).toBeInTheDocument();
+        expect(screen.getByText('01.04.2024 - 03.04.2024')).toBeInTheDocument();
       });
       
-      expect(screen.getByText('01.04.2024 - 03.04.2024')).toBeInTheDocument();
+      expect(screen.getByText('15.03.2024 - 17.03.2024')).toBeInTheDocument();
       expect(screen.getByText('Bestätigt')).toBeInTheDocument();
       expect(screen.getByText('Ausstehend')).toBeInTheDocument();
     });
@@ -237,13 +251,14 @@ describe('BookingsPage', () => {
       render(<BookingsPage />);
       
       await waitFor(() => {
-        expect(screen.getByText('15.03.2024 - 17.03.2024')).toBeInTheDocument();
+        expect(screen.getByText('01.04.2024 - 03.04.2024')).toBeInTheDocument();
       });
       
-      const bookingCard = screen.getByText('15.03.2024 - 17.03.2024').closest('div');
+      const bookingCard = screen.getByText('01.04.2024 - 03.04.2024').closest('div');
       fireEvent.click(bookingCard!);
       
-      expect(mockRouter.push).toHaveBeenCalledWith(`/bookings/${mockBookings[0].id}`);
+      // We clicked on the April booking (01.04.2024), which should navigate to that booking's ID
+      expect(mockRouter.push).toHaveBeenCalledWith('/bookings/987e6543-e89b-12d3-a456-426614174001');
     });
   });
 

--- a/src/frontend/app/bookings/__tests__/BookingsPage.test.tsx
+++ b/src/frontend/app/bookings/__tests__/BookingsPage.test.tsx
@@ -1,0 +1,463 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { useRouter } from 'next/navigation';
+import BookingsPage from '../page';
+import { apiClient } from '../../../lib/api/client';
+import { Booking, BookingStatus } from '../../../lib/types/api';
+
+// Mock dependencies
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock('../../../lib/api/client', () => ({
+  apiClient: {
+    getBookings: jest.fn(),
+    getToken: jest.fn(),
+    logout: jest.fn(),
+  },
+}));
+
+jest.mock('../../components/CreateBookingButton', () => {
+  return function CreateBookingButton({ onClick, variant }: { onClick: () => void; variant?: string }) {
+    return (
+      <button onClick={onClick} data-testid="create-booking-button">
+        {variant === 'large' ? 'Neue Buchung erstellen' : 'Buchung erstellen'}
+      </button>
+    );
+  };
+});
+
+const mockRouter = {
+  push: jest.fn(),
+};
+
+const mockBookings: Booking[] = [
+  {
+    id: '123e4567-e89b-12d3-a456-426614174000',
+    userId: 1,
+    userName: 'Test User',
+    userEmail: 'test@example.com',
+    startDate: '2024-03-15T00:00:00Z',
+    endDate: '2024-03-17T00:00:00Z',
+    numberOfNights: 2,
+    totalPersons: 4,
+    status: BookingStatus.Confirmed,
+    bookingItems: [
+      {
+        sleepingAccommodationId: '456e7890-e89b-12d3-a456-426614174001',
+        sleepingAccommodationName: 'Hauptschlafzimmer',
+        personCount: 2,
+      },
+      {
+        sleepingAccommodationId: '789e1234-e89b-12d3-a456-426614174002',
+        sleepingAccommodationName: 'Gästezimmer',
+        personCount: 2,
+      },
+    ],
+    notes: 'Test notes',
+    createdAt: '2024-03-01T10:00:00Z',
+    changedAt: '2024-03-02T15:30:00Z',
+  },
+  {
+    id: '987e6543-e89b-12d3-a456-426614174001',
+    userId: 1,
+    userName: 'Test User',
+    userEmail: 'test@example.com',
+    startDate: '2024-04-01T00:00:00Z',
+    endDate: '2024-04-03T00:00:00Z',
+    numberOfNights: 2,
+    totalPersons: 2,
+    status: BookingStatus.Pending,
+    bookingItems: [
+      {
+        sleepingAccommodationId: '456e7890-e89b-12d3-a456-426614174001',
+        sleepingAccommodationName: 'Hauptschlafzimmer',
+        personCount: 2,
+      },
+    ],
+    notes: undefined,
+    createdAt: '2024-03-20T12:00:00Z',
+    changedAt: undefined,
+  },
+];
+
+describe('BookingsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    (useRouter as jest.Mock).mockReturnValue(mockRouter);
+    
+    // Default successful mocks
+    (apiClient.getBookings as jest.Mock).mockResolvedValue(mockBookings);
+    
+    // Mock a proper JWT token for default tests
+    const payload = {
+      'http://schemas.microsoft.com/ws/2008/06/identity/claims/role': 'User'
+    };
+    const mockToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.' + btoa(JSON.stringify(payload)) + '.signature';
+    (apiClient.getToken as jest.Mock).mockReturnValue(mockToken);
+  });
+
+  describe('Loading States', () => {
+    it('should show loading spinner while fetching bookings', () => {
+      (apiClient.getBookings as jest.Mock).mockImplementation(() => new Promise(() => {}));
+      
+      render(<BookingsPage />);
+      
+      expect(screen.getByText('Buchungen werden geladen...')).toBeInTheDocument();
+      expect(document.querySelector('.animate-spin')).toBeInTheDocument();
+    });
+
+    it('should have proper loading spinner styling', () => {
+      (apiClient.getBookings as jest.Mock).mockImplementation(() => new Promise(() => {}));
+      
+      render(<BookingsPage />);
+      
+      const spinner = document.querySelector('.animate-spin');
+      expect(spinner).toHaveClass('w-8', 'h-8', 'border-4', 'border-blue-500/30', 'border-t-blue-500', 'rounded-full');
+    });
+  });
+
+  describe('Error States', () => {
+    it('should show error message when booking fetch fails', async () => {
+      const errorMessage = 'Fehler beim Laden der Buchungen';
+      (apiClient.getBookings as jest.Mock).mockRejectedValue(new Error(errorMessage));
+      
+      render(<BookingsPage />);
+      
+      await waitFor(() => {
+        expect(screen.getByText(errorMessage)).toBeInTheDocument();
+      });
+      
+      expect(screen.getByRole('button', { name: /neu laden/i })).toBeInTheDocument();
+    });
+
+    it('should show generic error message for unknown errors', async () => {
+      (apiClient.getBookings as jest.Mock).mockRejectedValue('Unknown error');
+      
+      render(<BookingsPage />);
+      
+      await waitFor(() => {
+        expect(screen.getByText('Fehler beim Laden der Buchungen')).toBeInTheDocument();
+      });
+    });
+
+    it('should redirect to login on 401 error', async () => {
+      (apiClient.getBookings as jest.Mock).mockRejectedValue({
+        status: 401,
+        message: 'Unauthorized'
+      });
+      
+      render(<BookingsPage />);
+      
+      await waitFor(() => {
+        expect(mockRouter.push).toHaveBeenCalledWith('/login');
+      });
+    });
+
+    it('should show retry button when booking fetch fails', async () => {
+      const errorMessage = 'Network error';
+      (apiClient.getBookings as jest.Mock).mockRejectedValue(new Error(errorMessage));
+      
+      render(<BookingsPage />);
+      
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /neu laden/i })).toBeInTheDocument();
+      });
+      
+      const retryButton = screen.getByRole('button', { name: /neu laden/i });
+      expect(retryButton).toBeInTheDocument();
+      expect(retryButton).toHaveClass('ml-auto', 'bg-red-100', 'hover:bg-red-200', 'text-red-800');
+    });
+  });
+
+  describe('Empty State', () => {
+    it('should show empty state when no bookings exist', async () => {
+      (apiClient.getBookings as jest.Mock).mockResolvedValue([]);
+      
+      render(<BookingsPage />);
+      
+      await waitFor(() => {
+        expect(screen.getByText('Noch keine Buchungen')).toBeInTheDocument();
+      });
+      
+      expect(screen.getByText('Sie haben noch keine Buchungen erstellt. Starten Sie mit Ihrer ersten Buchung!')).toBeInTheDocument();
+      expect(screen.getAllByTestId('create-booking-button')).toHaveLength(2); // One in header, one in empty state
+    });
+
+    it('should have proper empty state styling', async () => {
+      (apiClient.getBookings as jest.Mock).mockResolvedValue([]);
+      
+      render(<BookingsPage />);
+      
+      await waitFor(() => {
+        expect(screen.getByText('Noch keine Buchungen')).toBeInTheDocument();
+      });
+      
+      const emptyStateContainer = screen.getByText('Noch keine Buchungen').closest('div');
+      expect(emptyStateContainer).toHaveClass('bg-white', 'rounded-2xl', 'shadow-xl', 'p-12', 'text-center');
+    });
+  });
+
+  describe('Successful Loading', () => {
+    it('should display page header correctly', async () => {
+      render(<BookingsPage />);
+      
+      await waitFor(() => {
+        expect(screen.getByText('Meine Buchungen')).toBeInTheDocument();
+      });
+      
+      expect(screen.getByText('Verwalten Sie Ihre Garten-Buchungen')).toBeInTheDocument();
+    });
+
+    it('should display booking cards', async () => {
+      render(<BookingsPage />);
+      
+      await waitFor(() => {
+        expect(screen.getByText('15.03.2024 - 17.03.2024')).toBeInTheDocument();
+      });
+      
+      expect(screen.getByText('01.04.2024 - 03.04.2024')).toBeInTheDocument();
+      expect(screen.getByText('Bestätigt')).toBeInTheDocument();
+      expect(screen.getByText('Ausstehend')).toBeInTheDocument();
+    });
+
+    it('should use grid layout for bookings', async () => {
+      const { container } = render(<BookingsPage />);
+      
+      await waitFor(() => {
+        expect(screen.getByText('15.03.2024 - 17.03.2024')).toBeInTheDocument();
+      });
+      
+      const gridContainer = container.querySelector('.grid.grid-cols-1.lg\\:grid-cols-2.gap-6');
+      expect(gridContainer).toBeInTheDocument();
+    });
+
+    it('should navigate to booking detail when card is clicked', async () => {
+      render(<BookingsPage />);
+      
+      await waitFor(() => {
+        expect(screen.getByText('15.03.2024 - 17.03.2024')).toBeInTheDocument();
+      });
+      
+      const bookingCard = screen.getByText('15.03.2024 - 17.03.2024').closest('div');
+      fireEvent.click(bookingCard!);
+      
+      expect(mockRouter.push).toHaveBeenCalledWith(`/bookings/${mockBookings[0].id}`);
+    });
+  });
+
+  describe('Navigation', () => {
+    it('should show create booking button in header', async () => {
+      render(<BookingsPage />);
+      
+      await waitFor(() => {
+        expect(screen.getAllByTestId('create-booking-button').length).toBeGreaterThanOrEqual(1);
+      });
+    });
+
+    it('should navigate to new booking page when create button is clicked', async () => {
+      render(<BookingsPage />);
+      
+      await waitFor(() => {
+        expect(screen.getAllByTestId('create-booking-button').length).toBeGreaterThanOrEqual(1);
+      });
+      
+      const createButton = screen.getAllByTestId('create-booking-button')[0];
+      fireEvent.click(createButton);
+      
+      expect(mockRouter.push).toHaveBeenCalledWith('/bookings/new');
+    });
+
+    it('should show logout button', async () => {
+      render(<BookingsPage />);
+      
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /abmelden/i })).toBeInTheDocument();
+      });
+    });
+
+    it('should logout and redirect when logout button is clicked', async () => {
+      render(<BookingsPage />);
+      
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /abmelden/i })).toBeInTheDocument();
+      });
+      
+      const logoutButton = screen.getByRole('button', { name: /abmelden/i });
+      fireEvent.click(logoutButton);
+      
+      expect(apiClient.logout).toHaveBeenCalled();
+      expect(mockRouter.push).toHaveBeenCalledWith('/login');
+    });
+  });
+
+  describe('Admin Functionality', () => {
+    beforeEach(() => {
+      // Mock JWT token with Administrator role
+      const payload = {
+        'http://schemas.microsoft.com/ws/2008/06/identity/claims/role': 'Administrator'
+      };
+      const mockToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.' + btoa(JSON.stringify(payload)) + '.signature';
+      (apiClient.getToken as jest.Mock).mockReturnValue(mockToken);
+    });
+
+    it('should show admin button for administrators', async () => {
+      render(<BookingsPage />);
+      
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /admin/i })).toBeInTheDocument();
+      });
+    });
+
+    it('should navigate to admin page when admin button is clicked', async () => {
+      render(<BookingsPage />);
+      
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /admin/i })).toBeInTheDocument();
+      });
+      
+      const adminButton = screen.getByRole('button', { name: /admin/i });
+      fireEvent.click(adminButton);
+      
+      expect(mockRouter.push).toHaveBeenCalledWith('/admin');
+    });
+  });
+
+  describe('Non-Admin Functionality', () => {
+    beforeEach(() => {
+      // Mock JWT token with regular user role
+      const payload = {
+        'http://schemas.microsoft.com/ws/2008/06/identity/claims/role': 'User'
+      };
+      const mockToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.' + btoa(JSON.stringify(payload)) + '.signature';
+      (apiClient.getToken as jest.Mock).mockReturnValue(mockToken);
+    });
+
+    it('should not show admin button for regular users', async () => {
+      render(<BookingsPage />);
+      
+      await waitFor(() => {
+        expect(screen.getByText('Meine Buchungen')).toBeInTheDocument();
+      });
+      
+      expect(screen.queryByRole('button', { name: /admin/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Token Handling', () => {
+    it('should handle missing token gracefully', async () => {
+      (apiClient.getToken as jest.Mock).mockReturnValue(null);
+      
+      render(<BookingsPage />);
+      
+      await waitFor(() => {
+        expect(screen.getByText('Meine Buchungen')).toBeInTheDocument();
+      });
+      
+      // Should not crash and should not show admin button
+      expect(screen.queryByRole('button', { name: /admin/i })).not.toBeInTheDocument();
+    });
+
+    it('should handle malformed token gracefully', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      (apiClient.getToken as jest.Mock).mockReturnValue('invalid.token.parts');
+      
+      render(<BookingsPage />);
+      
+      await waitFor(() => {
+        expect(screen.getByText('Meine Buchungen')).toBeInTheDocument();
+      });
+      
+      // Should not crash and should not show admin button
+      expect(screen.queryByRole('button', { name: /admin/i })).not.toBeInTheDocument();
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('Responsive Design', () => {
+    it('should have responsive header layout', async () => {
+      const { container } = render(<BookingsPage />);
+      
+      await waitFor(() => {
+        expect(screen.getByText('Meine Buchungen')).toBeInTheDocument();
+      });
+      
+      const headerContainer = container.querySelector('.flex.flex-col.sm\\:flex-row.sm\\:items-center.sm\\:justify-between');
+      expect(headerContainer).toBeInTheDocument();
+    });
+
+    it('should have responsive grid layout', async () => {
+      const { container } = render(<BookingsPage />);
+      
+      await waitFor(() => {
+        expect(screen.getByText('15.03.2024 - 17.03.2024')).toBeInTheDocument();
+      });
+      
+      const gridContainer = container.querySelector('.grid-cols-1.lg\\:grid-cols-2');
+      expect(gridContainer).toBeInTheDocument();
+    });
+  });
+
+  describe('Visual Design', () => {
+    it('should have gradient background', async () => {
+      const { container } = render(<BookingsPage />);
+      
+      await waitFor(() => {
+        expect(screen.getByText('Meine Buchungen')).toBeInTheDocument();
+      });
+      
+      const mainContainer = container.querySelector('.bg-gradient-to-br.from-green-50.via-blue-50.to-indigo-100');
+      expect(mainContainer).toBeInTheDocument();
+    });
+
+    it('should have proper container max-width', async () => {
+      const { container } = render(<BookingsPage />);
+      
+      await waitFor(() => {
+        expect(screen.getByText('Meine Buchungen')).toBeInTheDocument();
+      });
+      
+      const contentContainer = container.querySelector('.max-w-6xl');
+      expect(contentContainer).toBeInTheDocument();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should have proper page heading', async () => {
+      render(<BookingsPage />);
+      
+      await waitFor(() => {
+        const heading = screen.getByRole('heading', { name: 'Meine Buchungen' });
+        expect(heading).toBeInTheDocument();
+        expect(heading.tagName).toBe('H1');
+      });
+    });
+
+    it('should have proper button labels', async () => {
+      render(<BookingsPage />);
+      
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /abmelden/i })).toBeInTheDocument();
+      });
+      
+      expect(screen.getByTestId('create-booking-button')).toBeInTheDocument();
+    });
+  });
+
+  describe('Error Handling Edge Cases', () => {
+    it('should handle console errors gracefully', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      (apiClient.getBookings as jest.Mock).mockRejectedValue(new Error('Network error'));
+      
+      render(<BookingsPage />);
+      
+      await waitFor(() => {
+        expect(screen.getByText('Network error')).toBeInTheDocument();
+      });
+      
+      expect(consoleSpy).toHaveBeenCalledWith('Fehler beim Laden der Buchungen:', expect.any(Error));
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/src/frontend/app/bookings/page.tsx
+++ b/src/frontend/app/bookings/page.tsx
@@ -136,7 +136,11 @@ export default function BookingsPage() {
 
     try {
       const data = await apiClient.getBookings();
-      setBookings(data);
+      // Sort bookings by start date (newest first)
+      const sortedBookings = data.sort((a, b) => 
+        new Date(b.startDate).getTime() - new Date(a.startDate).getTime()
+      );
+      setBookings(sortedBookings);
     } catch (err: unknown) {
       console.error('Fehler beim Laden der Buchungen:', err);
       const errorMessage = err && typeof err === 'object' && 'message' in err 

--- a/src/frontend/app/bookings/page.tsx
+++ b/src/frontend/app/bookings/page.tsx
@@ -136,11 +136,7 @@ export default function BookingsPage() {
 
     try {
       const data = await apiClient.getBookings();
-      // Sort bookings by start date (newest first)
-      const sortedBookings = data.sort((a, b) => 
-        new Date(b.startDate).getTime() - new Date(a.startDate).getTime()
-      );
-      setBookings(sortedBookings);
+      setBookings(data);
     } catch (err: unknown) {
       console.error('Fehler beim Laden der Buchungen:', err);
       const errorMessage = err && typeof err === 'object' && 'message' in err 

--- a/src/frontend/app/bookings/page.tsx
+++ b/src/frontend/app/bookings/page.tsx
@@ -89,7 +89,7 @@ function BookingCard({ booking, onClick }: BookingCardProps) {
         </div>
 
         {/* Booking Details */}
-        <div className="grid grid-cols-2 gap-4 mb-4">
+        <div className="grid grid-cols-3 gap-4 mb-4">
           <div className="flex items-center text-sm text-gray-600">
             <svg className="w-4 h-4 mr-2 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
@@ -102,18 +102,11 @@ function BookingCard({ booking, onClick }: BookingCardProps) {
             </svg>
             <span>{booking.totalPersons} {booking.totalPersons === 1 ? 'Person' : 'Personen'}</span>
           </div>
-        </div>
-
-        {/* Accommodations */}
-        <div className="space-y-2">
-          <p className="text-sm font-medium text-gray-700">Schlafmöglichkeiten:</p>
-          <div className="space-y-1">
-            {booking.bookingItems.map((item, index) => (
-              <div key={index} className="flex items-center justify-between text-sm bg-gray-50 rounded-lg px-3 py-2">
-                <span className="text-gray-900">{item.sleepingAccommodationName}</span>
-                <span className="text-gray-600">{item.personCount} {item.personCount === 1 ? 'Person' : 'Personen'}</span>
-              </div>
-            ))}
+          <div className="flex items-center text-sm text-gray-600">
+            <svg className="w-4 h-4 mr-2 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2-2v16m14 0V9a2 2 0 00-2-2H9a2 2 0 00-2-2v12a2 2 0 002 2h10a2 2 0 002-2z" />
+            </svg>
+            <span>{booking.bookingItems.length} {booking.bookingItems.length === 1 ? 'Schlafmöglichkeit' : 'Schlafmöglichkeiten'}</span>
           </div>
         </div>
 

--- a/src/frontend/app/bookings/page.tsx
+++ b/src/frontend/app/bookings/page.tsx
@@ -82,9 +82,6 @@ function BookingCard({ booking, onClick }: BookingCardProps) {
               </h3>
               {getStatusBadge(booking.status)}
             </div>
-            <p className="text-sm text-gray-600">
-              Buchungs-ID: {booking.id.slice(0, 8)}...
-            </p>
           </div>
         </div>
 
@@ -110,22 +107,7 @@ function BookingCard({ booking, onClick }: BookingCardProps) {
           </div>
         </div>
 
-        {/* Notes */}
-        {booking.notes && (
-          <div className="mt-4 p-3 bg-blue-50 rounded-lg">
-            <p className="text-sm text-blue-800">
-              <span className="font-medium">Notizen:</span> {booking.notes}
-            </p>
-          </div>
-        )}
 
-        {/* Creation Date */}
-        <div className="mt-4 pt-4 border-t border-gray-200">
-          <p className="text-xs text-gray-500">
-            Erstellt am {formatDate(booking.createdAt)}
-            {booking.changedAt && ` • Zuletzt geändert am ${formatDate(booking.changedAt)}`}
-          </p>
-        </div>
       </div>
 
       {/* Action Button */}


### PR DESCRIPTION
## Summary
Implements Issue #26: Booking list display with ascending StartDate sorting and simplified view.

### Key Changes
- **Frontend**: Simplified booking list display (removed booking ID, notes, detailed accommodations)
- **Backend**: Implemented ascending StartDate sorting in GetBookingsQuery
- **Tests**: Comprehensive frontend (56 tests) and backend (4 tests) coverage
- **Documentation**: Added critical rules to CLAUDE.md for issue focus and frontend-backend sync

### Implementation Details
- Booking list shows only essential information: dates, status, nights, persons, accommodation count
- Backend sorts bookings by StartDate ascending (earliest dates first)
- Removed non-required features like pagination and date filtering to focus on core requirements
- Maintained user/admin access control functionality
- All tests pass successfully

### Test Plan
- [x] Frontend component tests (BookingCard: 27 tests, BookingsPage: 29 tests)
- [x] Backend query handler tests (4 core tests covering sorting, filtering, admin access)
- [x] Manual verification of booking list display
- [x] Verification of ascending date sorting
- [x] User role functionality (regular user vs admin)

### Documentation Updates
- Added performance principles: backend-first for data operations
- Added strict issue-focusing rule: only implement explicitly required features
- Added frontend-backend synchronization requirement

🤖 Generated with [Claude Code](https://claude.ai/code)